### PR TITLE
使用nginx开启HTTP2后出现错误

### DIFF
--- a/Bumblebee/BadGateway.cs
+++ b/Bumblebee/BadGateway.cs
@@ -8,7 +8,7 @@ namespace Bumblebee
 {
     public class BadGateway : InnerErrorResult
     {
-        public IHeaderItem HTML_UTF8 = new ContentType("text/html; charset=utf-8\r\n");
+        public IHeaderItem HTML_UTF8 = new ContentType("text/html; charset=utf-8");
 
         public BadGateway(string errormsg, int code = 502) : base(code.ToString(), "Bad Gateway", new Exception(errormsg), false)
         {

--- a/Bumblebee/BadGateway.cs
+++ b/Bumblebee/BadGateway.cs
@@ -8,7 +8,7 @@ namespace Bumblebee
 {
     public class BadGateway : InnerErrorResult
     {
-        public IHeaderItem HTML_UTF8 = new HeaderItem("text/html; charset=utf-8\r\n");
+        public IHeaderItem HTML_UTF8 = new ContentType("text/html; charset=utf-8\r\n");
 
         public BadGateway(string errormsg, int code = 502) : base(code.ToString(), "Bad Gateway", new Exception(errormsg), false)
         {

--- a/Bumblebee/Gateway.cs
+++ b/Bumblebee/Gateway.cs
@@ -477,7 +477,7 @@ namespace Bumblebee
             HttpServer.HttpRequesting += OnHttpRequest;
             HttpServer.HttpDisconnect += OnHttpDisconnect;
             LoadConfig();
-            HeaderTypeFactory.SERVAR_HEADER_BYTES = Encoding.ASCII.GetBytes("Server :" + GATEWAY_VERSION + "\r\n");
+            HeaderTypeFactory.SERVAR_HEADER_BYTES = Encoding.ASCII.GetBytes("Server:" + GATEWAY_VERSION + "\r\n");
             PluginCenter.Load(typeof(Gateway).Assembly);
 
             mVerifyTimer = new Timer(OnVerifyTimer, null, 1000, 1000);


### PR DESCRIPTION
client--http2-->nginx--http1.1-->gateway

修复设置contenttype时缺失key值
修复server设置时多余的空格